### PR TITLE
Make protobluff compatible with C++11 and protobuf >3.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ AC_CONFIG_FILES([
 
 # Compiler flags
 CFLAGS+=" -std=c99"
-CXXFLAGS+=" -std=c++98"
+CXXFLAGS+=" -std=c++11"
 CPPFLAGS+=" -Wall -Wno-deprecated-declarations -Wno-address"
 
 # Output result

--- a/src/generator/enum.cc
+++ b/src/generator/enum.cc
@@ -44,7 +44,6 @@ namespace protobluff {
   using ::google::protobuf::EnumDescriptor;
   using ::google::protobuf::FieldDescriptor;
   using ::google::protobuf::io::Printer;
-  using ::google::protobuf::scoped_ptr;
 
   using ::google::protobuf::LowerString;
   using ::google::protobuf::SimpleItoa;
@@ -58,7 +57,7 @@ namespace protobluff {
   Enum::
   Enum(const EnumDescriptor *descriptor) :
       descriptor_(descriptor),
-      values_(new scoped_ptr<EnumValue>[descriptor_->value_count()]) {
+      values_(new std::unique_ptr<EnumValue>[descriptor_->value_count()]) {
 
     /* Sort enum value generators by number */
     vector<EnumValue *> sorted;

--- a/src/generator/enum.hh
+++ b/src/generator/enum.hh
@@ -43,8 +43,6 @@ namespace protobluff {
 
   using ::google::protobuf::EnumDescriptor;
   using ::google::protobuf::io::Printer;
-  using ::google::protobuf::scoped_array;
-  using ::google::protobuf::scoped_ptr;
 
   class Enum {
 
@@ -71,8 +69,8 @@ namespace protobluff {
 
   private:
     const EnumDescriptor *descriptor_; /* Enum descriptor */
-    scoped_array<
-      scoped_ptr<EnumValue>
+    std::unique_ptr<
+      std::unique_ptr<EnumValue>[]
     > values_;                         /* Enum value generators */
     map<string, string> variables_;    /* Variables */
   };

--- a/src/generator/field.cc
+++ b/src/generator/field.cc
@@ -53,7 +53,6 @@ namespace protobluff {
   using ::google::protobuf::EnumValueDescriptor;
   using ::google::protobuf::FieldDescriptor;
   using ::google::protobuf::io::Printer;
-  using ::google::protobuf::scoped_ptr;
 
   using ::google::protobuf::HasPrefixString;
   using ::google::protobuf::JoinStrings;
@@ -488,7 +487,7 @@ namespace protobluff {
         trace.push_back(descriptor_);
 
         /* Follow trace for corresponding message generator */
-        scoped_ptr<Message> temp(new Message(descriptor_->message_type()));
+        std::unique_ptr<Message> temp(new Message(descriptor_->message_type()));
         temp->GenerateAccessors(printer, trace);
       }
 
@@ -685,7 +684,7 @@ namespace protobluff {
         trace.push_back(descriptor_);
 
         /* Follow trace for corresponding message generator */
-        scoped_ptr<Message> temp(new Message(message));
+        std::unique_ptr<Message> temp(new Message(message));
         temp->GenerateAccessors(printer, trace);
         trace.pop_back();
       }

--- a/src/generator/file.cc
+++ b/src/generator/file.cc
@@ -52,7 +52,6 @@ namespace protobluff {
   using ::google::protobuf::FileDescriptor;
   using ::google::protobuf::FileOptions;
   using ::google::protobuf::io::Printer;
-  using ::google::protobuf::scoped_ptr;
 
   using ::google::protobuf::SimpleItoa;
   using ::google::protobuf::StringReplace;
@@ -70,8 +69,8 @@ namespace protobluff {
       mode_(descriptor_->options().has_optimize_for()
         ? descriptor_->options().optimize_for()
         : FileOptions::SPEED),
-      enums_(new scoped_ptr<Enum>[descriptor_->enum_type_count()]),
-      messages_(new scoped_ptr<Message>[descriptor_->message_type_count()]) {
+      enums_(new std::unique_ptr<Enum>[descriptor_->enum_type_count()]),
+      messages_(new std::unique_ptr<Message>[descriptor_->message_type_count()]) {
 
     /* Initialize enum generators */
     for (size_t e = 0; e < descriptor_->enum_type_count(); e++)

--- a/src/generator/file.hh
+++ b/src/generator/file.hh
@@ -49,8 +49,6 @@ namespace protobluff {
   using ::google::protobuf::FileDescriptor;
   using ::google::protobuf::FileOptions;
   using ::google::protobuf::io::Printer;
-  using ::google::protobuf::scoped_array;
-  using ::google::protobuf::scoped_ptr;
 
   class File {
 
@@ -90,11 +88,11 @@ namespace protobluff {
     const FileDescriptor *descriptor_; /* File descriptor */
     const FileOptions::OptimizeMode
       mode_;                           /* Optimization mode */
-    scoped_array<
-      scoped_ptr<Enum>
+    std::unique_ptr<
+      std::unique_ptr<Enum>[]
     > enums_;                          /* Enum generators */
-    scoped_array<
-      scoped_ptr<Message>
+    std::unique_ptr<
+      std::unique_ptr<Message>[]
     > messages_;                       /* Message generators */
     vector<Extension *> extensions_;   /* Extension generators */
     map<string, string> variables_;    /* Variables */

--- a/src/generator/generator.cc
+++ b/src/generator/generator.cc
@@ -46,7 +46,6 @@ namespace protobluff {
   using ::google::protobuf::FileDescriptor;
   using ::google::protobuf::io::Printer;
   using ::google::protobuf::io::ZeroCopyOutputStream;
-  using ::google::protobuf::scoped_ptr;
 
   using ::google::protobuf::StripSuffixString;
 
@@ -72,7 +71,7 @@ namespace protobluff {
 
     /* Generate header file */
     {
-      scoped_ptr<ZeroCopyOutputStream> output(
+      std::unique_ptr<ZeroCopyOutputStream> output(
         directory->Open(basename + ".h"));
       Printer printer (output.get(), '`');
       file.GenerateHeader(&printer);
@@ -80,7 +79,7 @@ namespace protobluff {
 
     /* Generate source file */
     {
-      scoped_ptr<ZeroCopyOutputStream> output(
+      std::unique_ptr<ZeroCopyOutputStream> output(
         directory->Open(basename + ".c"));
       Printer printer (output.get(), '`');
       file.GenerateSource(&printer);

--- a/src/generator/message.cc
+++ b/src/generator/message.cc
@@ -49,7 +49,6 @@ namespace protobluff {
   using ::google::protobuf::Descriptor;
   using ::google::protobuf::FieldDescriptor;
   using ::google::protobuf::io::Printer;
-  using ::google::protobuf::scoped_ptr;
 
   using ::google::protobuf::LowerString;
   using ::google::protobuf::SimpleItoa;
@@ -63,10 +62,10 @@ namespace protobluff {
   Message::
   Message(const Descriptor *descriptor) :
       descriptor_(descriptor),
-      fields_(new scoped_ptr<Field>[descriptor_->field_count()]),
-      enums_(new scoped_ptr<Enum>[descriptor_->enum_type_count()]),
-      oneofs_(new scoped_ptr<Oneof>[descriptor_->oneof_decl_count()]),
-      nested_(new scoped_ptr<Message>[descriptor_->nested_type_count()]) {
+      fields_(new std::unique_ptr<Field>[descriptor_->field_count()]),
+      enums_(new std::unique_ptr<Enum>[descriptor_->enum_type_count()]),
+      oneofs_(new std::unique_ptr<Oneof>[descriptor_->oneof_decl_count()]),
+      nested_(new std::unique_ptr<Message>[descriptor_->nested_type_count()]) {
 
     /* Sort field generators by tag */
     vector<Field *> sorted;

--- a/src/generator/message.hh
+++ b/src/generator/message.hh
@@ -49,8 +49,6 @@ namespace protobluff {
   using ::google::protobuf::Descriptor;
   using ::google::protobuf::FieldDescriptor;
   using ::google::protobuf::io::Printer;
-  using ::google::protobuf::scoped_array;
-  using ::google::protobuf::scoped_ptr;
 
   class Message {
 
@@ -132,17 +130,17 @@ namespace protobluff {
 
   private:
     const Descriptor *descriptor_;     /* Descriptor */
-    scoped_array<
-      scoped_ptr<Field>
+    std::unique_ptr<
+      std::unique_ptr<Field>[]
     > fields_;                         /* Field generators */
-    scoped_array<
-      scoped_ptr<Enum>
+    std::unique_ptr<
+      std::unique_ptr<Enum>[]
     > enums_;                          /* Enum generators */
-    scoped_array<
-      scoped_ptr<Oneof>
+    std::unique_ptr<
+      std::unique_ptr<Oneof>[]
     > oneofs_;                         /* Oneof generators */
-    scoped_array<
-      scoped_ptr<Message>
+    std::unique_ptr<
+      std::unique_ptr<Message>[]
     > nested_;                         /* Nested message generators */
     vector<Extension *> extensions_;   /* Extension generators */
     map<string, string> variables_;    /* Variables */

--- a/src/generator/oneof.cc
+++ b/src/generator/oneof.cc
@@ -46,7 +46,6 @@ namespace protobluff {
   using ::google::protobuf::FieldDescriptor;
   using ::google::protobuf::OneofDescriptor;
   using ::google::protobuf::io::Printer;
-  using ::google::protobuf::scoped_ptr;
 
   using ::google::protobuf::JoinStrings;
   using ::google::protobuf::LowerString;
@@ -61,7 +60,7 @@ namespace protobluff {
   Oneof::
   Oneof(const OneofDescriptor *descriptor) :
       descriptor_(descriptor),
-      fields_(new scoped_ptr<Field>[descriptor_->field_count()]) {
+      fields_(new std::unique_ptr<Field>[descriptor_->field_count()]) {
 
     /* Sort field generators by tag */
     vector<Field *> sorted;

--- a/src/generator/oneof.hh
+++ b/src/generator/oneof.hh
@@ -43,8 +43,6 @@ namespace protobluff {
 
   using ::google::protobuf::OneofDescriptor;
   using ::google::protobuf::io::Printer;
-  using ::google::protobuf::scoped_array;
-  using ::google::protobuf::scoped_ptr;
 
   class Oneof {
 
@@ -72,8 +70,8 @@ namespace protobluff {
   private:
     const OneofDescriptor
       *descriptor_;                    /* Oneof descriptor */
-    scoped_array<
-      scoped_ptr<Field>
+    std::unique_ptr<
+      std::unique_ptr<Field>[]
     > fields_;                         /* Field generators */
     map<string, string> variables_;    /* Variables */
   };

--- a/src/generator/strutil.cc
+++ b/src/generator/strutil.cc
@@ -185,8 +185,8 @@ void SplitStringToIteratorUsing(const string& full,
 
 void SplitStringUsing(const string& full,
                       const char* delim,
-                      vector<string>* result) {
-  std::back_insert_iterator< vector<string> > it(*result);
+                      std::vector<string>* result) {
+  std::back_insert_iterator< std::vector<string> > it(*result);
   SplitStringToIteratorUsing(full, delim, it);
 }
 
@@ -223,8 +223,8 @@ void SplitStringToIteratorAllowEmpty(const StringType& full,
 }
 
 void SplitStringAllowEmpty(const string& full, const char* delim,
-                           vector<string>* result) {
-  std::back_insert_iterator<vector<string> > it(*result);
+                           std::vector<string>* result) {
+  std::back_insert_iterator<std::vector<string> > it(*result);
   SplitStringToIteratorAllowEmpty(full, delim, 0, it);
 }
 
@@ -262,7 +262,7 @@ static void JoinStringsIterator(const ITERATOR& start,
   }
 }
 
-void JoinStrings(const vector<string>& components,
+void JoinStrings(const std::vector<string>& components,
                  const char* delim,
                  string * result) {
   JoinStringsIterator(components.begin(), components.end(), delim, result);
@@ -302,7 +302,7 @@ int UnescapeCEscapeSequences(const char* source, char* dest) {
 }
 
 int UnescapeCEscapeSequences(const char* source, char* dest,
-                             vector<string> *errors) {
+                             std::vector<string> *errors) {
   GOOGLE_DCHECK(errors == NULL) << "Error reporting not implemented.";
 
   char* d = dest;
@@ -438,8 +438,8 @@ int UnescapeCEscapeString(const string& src, string* dest) {
 }
 
 int UnescapeCEscapeString(const string& src, string* dest,
-                          vector<string> *errors) {
-  scoped_array<char> unescaped(new char[src.size() + 1]);
+                          std::vector<string> *errors) {
+  std::unique_ptr<char[]> unescaped(new char[src.size() + 1]);
   int len = UnescapeCEscapeSequences(src.c_str(), unescaped.get(), errors);
   GOOGLE_CHECK(dest);
   dest->assign(unescaped.get(), len);
@@ -447,7 +447,7 @@ int UnescapeCEscapeString(const string& src, string* dest,
 }
 
 string UnescapeCEscapeString(const string& src) {
-  scoped_array<char> unescaped(new char[src.size() + 1]);
+  std::unique_ptr<char[]> unescaped(new char[src.size() + 1]);
   int len = UnescapeCEscapeSequences(src.c_str(), unescaped.get(), NULL);
   return string(unescaped.get(), len);
 }
@@ -525,7 +525,7 @@ int CEscapeString(const char* src, int src_len, char* dest, int dest_len) {
 // ----------------------------------------------------------------------
 string CEscape(const string& src) {
   const int dest_length = src.size() * 4 + 1; // Maximum possible expansion
-  scoped_array<char> dest(new char[dest_length]);
+  std::unique_ptr<char[]> dest(new char[dest_length]);
   const int len = CEscapeInternal(src.data(), src.size(),
                                   dest.get(), dest_length, false, false);
   GOOGLE_DCHECK_GE(len, 0);
@@ -536,7 +536,7 @@ namespace strings {
 
 string Utf8SafeCEscape(const string& src) {
   const int dest_length = src.size() * 4 + 1; // Maximum possible expansion
-  scoped_array<char> dest(new char[dest_length]);
+  std::unique_ptr<char[]> dest(new char[dest_length]);
   const int len = CEscapeInternal(src.data(), src.size(),
                                   dest.get(), dest_length, false, true);
   GOOGLE_DCHECK_GE(len, 0);
@@ -545,7 +545,7 @@ string Utf8SafeCEscape(const string& src) {
 
 string CHexEscape(const string& src) {
   const int dest_length = src.size() * 4 + 1; // Maximum possible expansion
-  scoped_array<char> dest(new char[dest_length]);
+  std::unique_ptr<char[]> dest(new char[dest_length]);
   const int len = CEscapeInternal(src.data(), src.size(),
                                   dest.get(), dest_length, true, false);
   GOOGLE_DCHECK_GE(len, 0);

--- a/src/generator/strutil.hh
+++ b/src/generator/strutil.hh
@@ -166,7 +166,7 @@ LIBPROTOBUF_EXPORT string StringReplace(const string& s, const string& oldsub,
 //    over all of them.
 // ----------------------------------------------------------------------
 LIBPROTOBUF_EXPORT void SplitStringUsing(const string& full, const char* delim,
-                                         vector<string>* res);
+                                         std::vector<string>* res);
 
 // Split a string using one or more byte delimiters, presented
 // as a nul-terminated c string. Append the components to 'result'.
@@ -178,7 +178,7 @@ LIBPROTOBUF_EXPORT void SplitStringUsing(const string& full, const char* delim,
 // ----------------------------------------------------------------------
 LIBPROTOBUF_EXPORT void SplitStringAllowEmpty(const string& full,
                                               const char* delim,
-                                              vector<string>* result);
+                                              std::vector<string>* result);
 
 // ----------------------------------------------------------------------
 // JoinStrings()
@@ -188,10 +188,10 @@ LIBPROTOBUF_EXPORT void SplitStringAllowEmpty(const string& full,
 //    another takes a pointer to the target string. In the latter case the
 //    target string is cleared and overwritten.
 // ----------------------------------------------------------------------
-LIBPROTOBUF_EXPORT void JoinStrings(const vector<string>& components,
+LIBPROTOBUF_EXPORT void JoinStrings(const std::vector<string>& components,
                                     const char* delim, string* result);
 
-inline string JoinStrings(const vector<string>& components,
+inline string JoinStrings(const std::vector<string>& components,
                           const char* delim) {
   string result;
   JoinStrings(components, delim, &result);
@@ -231,7 +231,7 @@ inline string JoinStrings(const vector<string>& components,
 
 LIBPROTOBUF_EXPORT int UnescapeCEscapeSequences(const char* source, char* dest);
 LIBPROTOBUF_EXPORT int UnescapeCEscapeSequences(const char* source, char* dest,
-                                                vector<string> *errors);
+                                                std::vector<string> *errors);
 
 // ----------------------------------------------------------------------
 // UnescapeCEscapeString()
@@ -250,7 +250,7 @@ LIBPROTOBUF_EXPORT int UnescapeCEscapeSequences(const char* source, char* dest,
 
 LIBPROTOBUF_EXPORT int UnescapeCEscapeString(const string& src, string* dest);
 LIBPROTOBUF_EXPORT int UnescapeCEscapeString(const string& src, string* dest,
-                                             vector<string> *errors);
+                                             std::vector<string> *errors);
 LIBPROTOBUF_EXPORT string UnescapeCEscapeString(const string& src);
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
- replace 'scoped_ptr' and 'scoped_array' with 'std::unique_ptr'
- prepend 'std::' to 'vector'