### PR TITLE
Fix compilation error when including in C++ units.

### DIFF
--- a/include/protobluff/core/buffer.h
+++ b/include/protobluff/core/buffer.h
@@ -44,30 +44,30 @@ typedef struct pb_buffer_t {
  * Interface
  * ------------------------------------------------------------------------- */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_buffer_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_buffer_t
 pb_buffer_create(
   const uint8_t data[],                /* Raw data */
   size_t size);                        /* Raw data size */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_buffer_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_buffer_t
 pb_buffer_create_with_allocator(
   pb_allocator_t *allocator,           /* Allocator */
   const uint8_t data[],                /* Raw data */
   size_t size);                        /* Raw data size */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_buffer_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_buffer_t
 pb_buffer_create_empty(void);
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_buffer_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_buffer_t
 pb_buffer_create_empty_with_allocator(
   pb_allocator_t *allocator);          /* Allocator */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_buffer_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_buffer_t
 pb_buffer_create_zero_copy(
   uint8_t data[],                      /* Raw data */
   size_t size);                        /* Raw data size */

--- a/include/protobluff/core/decoder.h
+++ b/include/protobluff/core/decoder.h
@@ -51,8 +51,8 @@ typedef struct pb_decoder_t {
  * Interface
  * ------------------------------------------------------------------------- */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_decoder_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_decoder_t
 pb_decoder_create(
   const pb_descriptor_t
     *descriptor,                       /* Descriptor */
@@ -62,8 +62,8 @@ PB_EXPORT void
 pb_decoder_destroy(
   pb_decoder_t *decoder);              /* Decoder */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_decoder_decode(
   const pb_decoder_t *decoder,         /* Decoder */
   pb_decoder_handler_f handler,        /* Handler */

--- a/include/protobluff/core/encoder.h
+++ b/include/protobluff/core/encoder.h
@@ -45,13 +45,13 @@ typedef struct pb_encoder_t {
  * Interface
  * ------------------------------------------------------------------------- */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_encoder_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_encoder_t
 pb_encoder_create(
   const pb_descriptor_t *descriptor);  /* Descriptor */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_encoder_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_encoder_t
 pb_encoder_create_with_allocator(
   pb_allocator_t *allocator,           /* Allocator */
   const pb_descriptor_t *descriptor);  /* Descriptor */
@@ -60,8 +60,8 @@ PB_EXPORT void
 pb_encoder_destroy(
   pb_encoder_t *encoder);              /* Encoder */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_encoder_encode(
   pb_encoder_t *encoder,               /* Encoder */
   pb_tag_t tag,                        /* Tag */

--- a/include/protobluff/message/cursor.h
+++ b/include/protobluff/message/cursor.h
@@ -51,14 +51,14 @@ typedef struct pb_cursor_t {
  * Interface
  * ------------------------------------------------------------------------- */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_cursor_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_cursor_t
 pb_cursor_create(
   pb_message_t *message,               /* Message */
   pb_tag_t tag);                       /* Tag */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_cursor_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_cursor_t
 pb_cursor_create_nested(
   pb_message_t *message,               /* Message */
   const pb_tag_t tags[],               /* Tags */
@@ -90,20 +90,20 @@ pb_cursor_match(
   pb_cursor_t *cursor,                 /* Cursor */
   const void *value);                  /* Pointer holding value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_cursor_get(
   pb_cursor_t *cursor,                 /* Cursor */
   void *value);                        /* Pointer receiving value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_cursor_put(
   pb_cursor_t *cursor,                 /* Cursor */
   const void *value);                  /* Pointer holding value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_cursor_erase(
   pb_cursor_t *cursor);                /* Cursor */
 

--- a/include/protobluff/message/field.h
+++ b/include/protobluff/message/field.h
@@ -51,21 +51,21 @@ typedef struct pb_field_t {
  * Interface
  * ------------------------------------------------------------------------- */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_field_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_field_t
 pb_field_create(
   struct pb_message_t *message,        /* Message */
   pb_tag_t tag);                       /* Tag */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_field_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_field_t
 pb_field_create_nested(
   struct pb_message_t *message,        /* Message */
   const pb_tag_t tags[],               /* Tags */
   size_t size);                        /* Tag count */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_field_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_field_t
 pb_field_create_from_cursor(
   struct pb_cursor_t *cursor);         /* Cursor */
 
@@ -78,20 +78,20 @@ pb_field_match(
   pb_field_t *field,                   /* Field */
   const void *value);                  /* Pointer holding value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_field_get(
   pb_field_t *field,                   /* Field */
   void *value);                        /* Pointer receiving value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_field_put(
   pb_field_t *field,                   /* Field */
   const void *value);                  /* Pointer holding value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_field_clear(
   pb_field_t *field);                  /* Field */
 

--- a/include/protobluff/message/journal.h
+++ b/include/protobluff/message/journal.h
@@ -53,30 +53,30 @@ typedef struct pb_journal_t {
  * Interface
  * ------------------------------------------------------------------------- */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_journal_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_journal_t
 pb_journal_create(
   const uint8_t data[],                /* Raw data */
   size_t size);                        /* Raw data size */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_journal_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_journal_t
 pb_journal_create_with_allocator(
   pb_allocator_t *allocator,           /* Allocator */
   const uint8_t data[],                /* Raw data */
   size_t size);                        /* Raw data size */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_journal_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_journal_t
 pb_journal_create_empty(void);
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_journal_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_journal_t
 pb_journal_create_empty_with_allocator(
   pb_allocator_t *allocator);          /* Allocator */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_journal_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_journal_t
 pb_journal_create_zero_copy(
   uint8_t data[],                      /* Raw data */
   size_t size);                        /* Raw data size */

--- a/include/protobluff/message/message.h
+++ b/include/protobluff/message/message.h
@@ -51,32 +51,32 @@ typedef struct pb_message_t {
  * Interface
  * ------------------------------------------------------------------------- */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_message_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_message_t
 pb_message_create(
   const pb_descriptor_t *descriptor,   /* Descriptor */
   pb_journal_t *journal);              /* Journal */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_message_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_message_t
 pb_message_create_within(
   pb_message_t *message,               /* Message */
   pb_tag_t tag);                       /* Tag */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_message_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_message_t
 pb_message_create_nested(
   pb_message_t *message,               /* Message */
   const pb_tag_t tags[],               /* Tags */
   size_t size);                        /* Tag count */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_message_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_message_t
 pb_message_create_from_cursor(
   struct pb_cursor_t *cursor);         /* Cursor */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_message_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_message_t
 pb_message_create_from_field(
   const pb_descriptor_t *descriptor,   /* Descriptor */
   struct pb_field_t *field);           /* Bytes field */
@@ -100,28 +100,28 @@ pb_message_match(
   pb_tag_t tag,                        /* Tag */
   const void *value);                  /* Pointer holding value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_message_get(
   pb_message_t *message,               /* Message */
   pb_tag_t tag,                        /* Tag */
   void *value);                        /* Pointer receiving value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_message_put(
   pb_message_t *message,               /* Message */
   pb_tag_t tag,                        /* Tag */
   const void *value);                  /* Pointer holding value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_message_erase(
   pb_message_t *message,               /* Message */
   pb_tag_t tag);                       /* Tag */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_message_clear(
   pb_message_t *message);              /* Message */
 

--- a/include/protobluff/message/nested.h
+++ b/include/protobluff/message/nested.h
@@ -45,24 +45,24 @@ pb_message_nested_match(
   size_t size,                         /* Tag count */
   const void *value);                  /* Pointer holding value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_message_nested_get(
   pb_message_t *message,               /* Message */
   const pb_tag_t tags[],               /* Tags */
   size_t size,                         /* Tag count */
   void *value);                        /* Pointer receiving value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_message_nested_put(
   pb_message_t *message,               /* Message */
   const pb_tag_t tags[],               /* Tags */
   size_t size,                         /* Tag count */
   const void *value);                  /* Pointer holding value */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_message_nested_erase(
   pb_message_t *message,               /* Message */
   const pb_tag_t tags[],               /* Tags */

--- a/include/protobluff/message/oneof.h
+++ b/include/protobluff/message/oneof.h
@@ -49,8 +49,8 @@ typedef struct pb_oneof_t {
  * Interface
  * ------------------------------------------------------------------------- */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_oneof_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_oneof_t
 pb_oneof_create(
   const pb_oneof_descriptor_t
     *descriptor,                       /* Oneof descriptor */
@@ -64,8 +64,8 @@ PB_EXPORT pb_tag_t
 pb_oneof_case(
   pb_oneof_t *oneof);                  /* Oneof */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_oneof_clear(
   pb_oneof_t *oneof);                  /* Oneof */
 

--- a/include/protobluff/util/chunk_allocator.h
+++ b/include/protobluff/util/chunk_allocator.h
@@ -32,12 +32,12 @@
  * Interface
  * ------------------------------------------------------------------------- */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_allocator_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_allocator_t
 pb_chunk_allocator_create();
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_allocator_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_allocator_t
 pb_chunk_allocator_create_with_capacity(
   size_t capacity);                    /* Chunk capacity */
 

--- a/include/protobluff/util/validator.h
+++ b/include/protobluff/util/validator.h
@@ -41,8 +41,8 @@ typedef struct pb_validator_t {
  * Interface
  * ------------------------------------------------------------------------- */
 
-PB_WARN_UNUSED_RESULT
-PB_EXPORT pb_error_t
+PB_EXPORT PB_WARN_UNUSED_RESULT
+pb_error_t
 pb_validator_check(
   const pb_validator_t *validator,     /* Validator */
   const pb_buffer_t *buffer);          /* Buffer */


### PR DESCRIPTION
Hi!

After using this in a project of mine, I experienced some compilation problems when including the headerfiles in C++ compilation units.

It boiled down to a pretty simple thing as explained in the commit:
> For C++ (and atleast g++), `extern "C"` (aka. PB_EXPORT for us) must be
> the first thing in a (function) declaration.
> Thus, just reorder things - swap all PB_WARN_UNUSED_RESULT with
> PB_EXPORT to resolve this issue.